### PR TITLE
providing the list of all generated images.

### DIFF
--- a/object-detection/solution/utils/data_collection.py
+++ b/object-detection/solution/utils/data_collection.py
@@ -105,6 +105,7 @@ while True:
         break
 
 
+all_image_names = [str(idx) for idx in range(npz_index)]
 train_test_split(all_image_names, SPLIT_PERCENTAGE, DATASET_DIR)
 
 #run(f"rm -rf {DATASET_DIR}/images {DATASET_DIR}/labels")


### PR DESCRIPTION
`all_image_names` is not defined and it is needed for the
train test split.

For the data collection use case, the image names can be simply
generated from the number of images that were saved: `npz_index`.

Otherwise, running the Data Collection generation application
will throw an error complaining that `all_image_names` is not defined.